### PR TITLE
Add openssl as dependency because rust crate depends on object_store_ffi

### DIFF
--- a/iceberg_rust_ffi_binarybuilder/build_tarballs.jl
+++ b/iceberg_rust_ffi_binarybuilder/build_tarballs.jl
@@ -31,7 +31,9 @@ products = [
 ]
 
 # Dependencies that must be installed before this package can be built
-dependencies = Dependency[]
+dependencies = Dependency[
+    Dependency("OpenSSL_jll"; compat="3.0.14")
+]
 
 # Build the tarballs
 build_tarballs(


### PR DESCRIPTION
…crate which has this dependency. ideally this shouldn't happen, if we pulled out only the common stuff, I think